### PR TITLE
开启Rhino沙箱限制

### DIFF
--- a/sun-dependencies/src/main/java/com/sun/script/javascript/RhinoClassShutter.java
+++ b/sun-dependencies/src/main/java/com/sun/script/javascript/RhinoClassShutter.java
@@ -53,6 +53,9 @@ final class RhinoClassShutter implements ClassShutter {
             // For now, we just have AccessController. Allowing scripts
             // to this class will allow it to execute doPrivileged in
             // bootstrap context. We can add more classes for other reasons.
+            protectedClasses.put("java.lang.Class", Boolean.TRUE);
+            protectedClasses.put("java.lang.Runtime", Boolean.TRUE);
+            protectedClasses.put("java.io.File", Boolean.TRUE);
             protectedClasses.put("java.security.AccessController", Boolean.TRUE);
         }
         return theInstance;

--- a/sun-dependencies/src/main/java/com/sun/script/javascript/RhinoWrapFactory.java
+++ b/sun-dependencies/src/main/java/com/sun/script/javascript/RhinoWrapFactory.java
@@ -73,10 +73,21 @@ final class RhinoWrapFactory extends WrapFactory {
             // field of NativeJavaObject.
             javaObject = obj;
         }
+
+        @Override
+        public Object get(String name, Scriptable start) {
+            if (name.equals("getClass") || name.equals("exec")) {
+                return NOT_FOUND;
+            }
+            return super.get(name, start);
+        }
     }
 
     public Scriptable wrapAsJavaObject(Context cx, Scriptable scope,
             Object javaObject, Class staticType) {
+        if (scope != null) {
+            scope.delete("Packages");
+        }
         SecurityManager sm = System.getSecurityManager();
         ClassShutter classShutter = RhinoClassShutter.getInstance();
         if (javaObject instanceof ClassLoader) {


### PR DESCRIPTION
* 禁止在js里exec运行命令
* 禁止在js里通过geClass反射
* 禁止在js里创建File对象
* 禁止在js里获取Packages scope

开启限制后以下js将不能执行
```javascript
var input= Packages.java['lang']['Ru'+'ntime']['getR'+'untime']()['exec']('whoami').getInputStream(); 
u = new Packages.java.util.Scanner(input, "UTF-8").useDelimiter("AA").next(); 
u
```
